### PR TITLE
[Fix] 긴 이름의 버스정류장 width 수정

### DIFF
--- a/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
+++ b/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
@@ -34,7 +34,7 @@ public final class BusStopInfoHeaderView: UIView {
         return label
     }()
     
-    private let busStopNameLb: UILabel = {
+    public let busStopNameLb: UILabel = {
         let label = UILabel()
         label.font = DesignSystemFontFamily.NanumSquareNeoOTF
             .extraBold.font(size: 18)
@@ -136,6 +136,7 @@ extension BusStopInfoHeaderView {
                 constant: 10
             ),
             busStopNameLb.heightAnchor.constraint(equalToConstant: 18),
+            busStopNameLb.centerXAnchor.constraint(equalTo: centerXAnchor),
             nextStopNameLb.topAnchor.constraint(
                 equalTo: busStopNameLb.bottomAnchor,
                 constant: 10

--- a/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
+++ b/Projects/Feature/BusStopFeature/Sources/View/BusStopInfoHeaderView.swift
@@ -39,6 +39,7 @@ public final class BusStopInfoHeaderView: UIView {
         label.font = DesignSystemFontFamily.NanumSquareNeoOTF
             .extraBold.font(size: 18)
         label.textColor = .white
+        label.textAlignment = .center
         return label
     }()
     
@@ -136,7 +137,14 @@ extension BusStopInfoHeaderView {
                 constant: 10
             ),
             busStopNameLb.heightAnchor.constraint(equalToConstant: 18),
-            busStopNameLb.centerXAnchor.constraint(equalTo: centerXAnchor),
+            busStopNameLb.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: 15
+            ),
+            busStopNameLb.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -15
+            ),
             nextStopNameLb.topAnchor.constraint(
                 equalTo: busStopNameLb.bottomAnchor,
                 constant: 10

--- a/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
+++ b/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
@@ -112,23 +112,12 @@ public final class BusStopViewController: UIViewController {
             .withUnretained(self)
             .subscribe(
                 onNext: { viewController, response in
-                    if response.busStopName.count > 20 {
-                        viewController.headerView.busStopNameLb
-                            .widthAnchor.constraint(
-                                equalToConstant: .screenWidth - 20
-                            ).isActive = true
-                        viewController.headerView.bindUI(
-                            routeId: response.busStopId,
-                            busStopName: response.busStopName,
-                            nextStopName: response.direction
-                        )
-                    } else {
-                        viewController.headerView.bindUI(
-                            routeId: response.busStopId,
-                            busStopName: response.busStopName,
-                            nextStopName: response.direction
-                        )
-                    }
+                    
+                    viewController.headerView.bindUI(
+                        routeId: response.busStopId,
+                        busStopName: response.busStopName,
+                        nextStopName: response.direction
+                    )
                     
                     viewController.updateSnapshot(busStopResponse: response)
                 }

--- a/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
+++ b/Projects/Feature/BusStopFeature/Sources/ViewController/BusStopViewController.swift
@@ -112,11 +112,23 @@ public final class BusStopViewController: UIViewController {
             .withUnretained(self)
             .subscribe(
                 onNext: { viewController, response in
-                    viewController.headerView.bindUI(
-                        routeId: response.busStopId,
-                        busStopName: response.busStopName,
-                        nextStopName: response.direction
-                    )
+                    if response.busStopName.count > 20 {
+                        viewController.headerView.busStopNameLb
+                            .widthAnchor.constraint(
+                                equalToConstant: .screenWidth - 20
+                            ).isActive = true
+                        viewController.headerView.bindUI(
+                            routeId: response.busStopId,
+                            busStopName: response.busStopName,
+                            nextStopName: response.direction
+                        )
+                    } else {
+                        viewController.headerView.bindUI(
+                            routeId: response.busStopId,
+                            busStopName: response.busStopName,
+                            nextStopName: response.direction
+                        )
+                    }
                     
                     viewController.updateSnapshot(busStopResponse: response)
                 }
@@ -265,6 +277,10 @@ public final class BusStopViewController: UIViewController {
 
 extension BusStopViewController {
     private func configureUI() {
+        [scrollView, contentView, headerView, busStopTableView]
+            .forEach { components in
+                components.translatesAutoresizingMaskIntoConstraints = false
+            }
         
         view.addSubview(scrollView)
         
@@ -274,11 +290,6 @@ extension BusStopViewController {
             }
         
         scrollView.addSubview(contentView)
-        
-        [scrollView, contentView, headerView, busStopTableView]
-            .forEach { components in
-                components.translatesAutoresizingMaskIntoConstraints = false
-            }
         
         tableViewHeightConstraint = busStopTableView.heightAnchor
             .constraint(equalToConstant: 0)


### PR DESCRIPTION
## 작업내용
1. 2줄로 내리니까 중앙 정렬에 어려움 O -> 2줄 내리기 X
2. 단순히 width를 leading에서 15, trailing에서 -15 했을 때, 짧은 것들이 왼쪽으로 붙는 현상
3. centerX로 두고, bindUI()를 통해 데이터 값을 넘겨줄 때 label의 width 값을 지정하여 ... 되게 처리


| 2번 이름 긴 정류장 | 2번 이름 짧은 정류장 | 3번 긴 정류장 | 3번 짧은 정류장 | 
| ----- | ----- | ----- | ----- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 21 26 47](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/a95a4f73-e09e-4784-9db7-9dd1ca6b6317) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 21 26 53](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/f6d224f4-2928-4c6b-99d4-937f39758ca5) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 21 26 01](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/8e975b3f-8d74-418f-8919-34fdbf018b7b) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 21 25 54](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/bc59384f-9378-4e90-9c7a-4fa6ff277d73)) |

## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #179 