### PR TITLE
Fix/#228

### DIFF
--- a/Projects/Core/Sources/Extension/Sequence+.swift
+++ b/Projects/Core/Sources/Extension/Sequence+.swift
@@ -1,0 +1,48 @@
+//
+//  Sequence+.swift
+//  Core
+//
+//  Created by gnksbm on 4/14/24.
+//  Copyright © 2024 Pepsi-Club. All rights reserved.
+//
+
+import Foundation
+
+public extension Sequence {
+    /**
+     키패스로 배열의 요소를 비교해 중복되지 않는 요소를 반환하는 함수
+     
+     - Parameters:
+       - target: 비교할 타겟 배열
+       - sourceKeyPath: 원본 배열의 요소를 식별하는 키패스
+       - targetKeyPath: 타겟 배열의 요소를 식별하는 키패스
+     
+     - Returns: (sourceMissing: 타겟 배열에만 존재하는 요소들,
+        targetMissing: 원본 배열에만 존재하는 요소들)
+     */
+    func compareDiff<Target, ComparableKeyPath: Hashable>(
+        sourceKeyPath: KeyPath<Element, ComparableKeyPath>,
+        target: [Target],
+        targetKeyPath: KeyPath<Target, ComparableKeyPath>
+    ) -> (sourceMissing: [Target], targetMissing: [Element]) {
+        let sourceDic = Dictionary(
+            uniqueKeysWithValues: map {
+                ($0[keyPath: sourceKeyPath], $0)
+            }
+        )
+        let targetDic = Dictionary(
+            uniqueKeysWithValues: target.map {
+                ($0[keyPath: targetKeyPath], $0)
+            }
+        )
+        
+        let sourceMissing = target.filter { targetElement in
+            sourceDic[targetElement[keyPath: targetKeyPath]] == nil
+        }
+        let targetMissing = filter { sourceElement in
+            targetDic[sourceElement[keyPath: sourceKeyPath]] == nil
+        }
+        
+        return (sourceMissing, targetMissing)
+    }
+}

--- a/Projects/Core/Sources/Extension/String+.swift
+++ b/Projects/Core/Sources/Extension/String+.swift
@@ -30,13 +30,6 @@ public extension String {
         return serverKey
     }
     
-    static var fcmKey: Self {
-        guard let any = Bundle.main.object(forInfoDictionaryKey: "FCM_KEY"),
-              let serverKey = any as? String
-        else { fatalError("Can't Not Find FCM Key") }
-        return serverKey
-    }
-    
     static func getCurrentVersion() -> String {
         guard let dictionary = Bundle.main.infoDictionary,
               let version = dictionary["CFBundleShortVersionString"] as? String

--- a/Projects/Data/Sources/DTO/FetchRegularAlarmDTO.swift
+++ b/Projects/Data/Sources/DTO/FetchRegularAlarmDTO.swift
@@ -1,0 +1,46 @@
+//
+//  FetchRegularAlarmDTO.swift
+//  Data
+//
+//  Created by gnksbm on 4/14/24.
+//  Copyright © 2024 Pepsi-Club. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+struct FetchRegularAlarmDTO: Decodable {
+    let alarmId: String
+    let time: String
+    let weekday: [Int]
+    let busId: String
+    let busStopId: String
+}
+
+extension Array<FetchRegularAlarmDTO> {
+    func validateSync(
+        localResponses: [RegularAlarmResponse]
+    ) -> RegularAlarmSyncValidation {
+        let (serverMissingAlarms, localMissingAlarm) = compareDiff(
+            sourceKeyPath: \.alarmId,
+            target: localResponses,
+            targetKeyPath: \.requestId
+        )
+        let localMissingAlarmIds = localMissingAlarm.map { $0.alarmId }
+        return RegularAlarmSyncValidation(
+            localMissingAlarmIds: localMissingAlarmIds,
+            serverMissingAlarms: serverMissingAlarms
+        )
+    }
+}
+
+extension FetchRegularAlarmDTO {
+    enum CodingKeys: String, CodingKey {
+        case alarmId = "id"
+        case time
+        case weekday = "day"
+        case busId = "busRoutedId"
+        case busStopId = "arsId"
+    }
+}

--- a/Projects/Data/Sources/DTO/RegularAlarmSyncValidation.swift
+++ b/Projects/Data/Sources/DTO/RegularAlarmSyncValidation.swift
@@ -1,0 +1,43 @@
+//
+//  RegularAlarmSyncValidation.swift
+//  Data
+//
+//  Created by gnksbm on 4/14/24.
+//  Copyright © 2024 Pepsi-Club. All rights reserved.
+//
+
+import Foundation
+
+import Core
+import Domain
+
+enum RegularAlarmSyncValidation {
+    case synced
+    case localMissing(alarmIds: [String])
+    case serverMissing(responses: [RegularAlarmResponse])
+    case bothMissing(
+        localMissingAlarmIds: [String],
+        serverMissingResponses: [RegularAlarmResponse]
+    )
+    
+    init(
+        localMissingAlarmIds: [String],
+        serverMissingAlarms: [RegularAlarmResponse]
+    ) {
+        let isLocalMissed = !localMissingAlarmIds.isEmpty
+        let isServerMissed = !serverMissingAlarms.isEmpty
+        switch (isLocalMissed, isServerMissed) {
+        case (false, false):
+            self = .synced
+        case (true, false):
+            self = .localMissing(alarmIds: localMissingAlarmIds)
+        case (false, true):
+            self = .serverMissing(responses: serverMissingAlarms)
+        case (true, true):
+            self = .bothMissing(
+                localMissingAlarmIds: localMissingAlarmIds,
+                serverMissingResponses: serverMissingAlarms
+            )
+        }
+    }
+}

--- a/Projects/Data/Sources/Repository/DefaultRegularAlarmRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultRegularAlarmRepository.swift
@@ -192,8 +192,20 @@ public final class DefaultRegularAlarmRepository: RegularAlarmRepository {
                 type: AddRegularAlarmDTO.self,
                 decoder: JSONDecoder()
             )
-            .subscribe() // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
-            .dispose()
+            .subscribe(
+                onNext: { dto in
+                    #if DEBUG
+                    print(dto)
+                    print("id: \(response.requestId)")
+                    #endif
+                },
+                onError: { error in
+                    #if DEBUG
+                    print(error.localizedDescription)
+                    #endif
+                }
+            ) // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
+            .disposed(by: disposeBag)
         }
     }
     
@@ -208,8 +220,20 @@ public final class DefaultRegularAlarmRepository: RegularAlarmRepository {
                 type: RemoveRegularAlarmDTO.self,
                 decoder: JSONDecoder()
             )
-            .subscribe() // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
-            .dispose()
+            .subscribe(
+                onNext: { dto in
+                    #if DEBUG
+                    print(dto)
+                    print("id: \(alarmId)")
+                    #endif
+                },
+                onError: { error in
+                    #if DEBUG
+                    print(error.localizedDescription)
+                    #endif
+                }
+            ) // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
+            .disposed(by: disposeBag)
         }
     }
 }

--- a/Projects/Data/Sources/Repository/DefaultRegularAlarmRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultRegularAlarmRepository.swift
@@ -54,7 +54,11 @@ public final class DefaultRegularAlarmRepository: RegularAlarmRepository {
             onNext: { repository, response in
                 do {
                     try repository.coreDataService.save(data: response)
-                    repository.fetchRegularAlarm()
+                    let currentAlarms = try repository.currentRegularAlarm
+                        .value()
+                    repository.currentRegularAlarm.onNext(
+                        currentAlarms + [response]
+                    )
                     completion()
                 } catch {
                     #if DEBUG
@@ -110,7 +114,11 @@ public final class DefaultRegularAlarmRepository: RegularAlarmRepository {
                         data: response,
                         uniqueKeyPath: \.requestId
                     )
-                    repository.fetchRegularAlarm()
+                    let currentAlarms = try repository.currentRegularAlarm
+                        .value()
+                    repository.currentRegularAlarm.onNext(
+                        currentAlarms.filter { $0 != response }
+                    )
                     completion()
                 } catch {
                     #if DEBUG
@@ -133,8 +141,75 @@ public final class DefaultRegularAlarmRepository: RegularAlarmRepository {
                 type: RegularAlarmResponse.self
             )
             currentRegularAlarm.onNext(responses)
+            syncRegularAlarms(responses: responses)
         } catch {
             currentRegularAlarm.onError(error)
+        }
+    }
+    
+    private func syncRegularAlarms(responses: [RegularAlarmResponse]) {
+        networkService.request(endPoint: FetchRegularAlarmEndPoint())
+            .decode(
+                type: [FetchRegularAlarmDTO].self,
+                decoder: JSONDecoder()
+            )
+            .withUnretained(self)
+            .subscribe(
+                onNext: { repository, dtoArr in
+                    switch dtoArr.validateSync(localResponses: responses) {
+                    case .synced:
+                        break
+                    case .localMissing(alarmIds: let alarmIds):
+                        repository.removeUnsyncedServerAlarm(alarmIds: alarmIds)
+                    case .serverMissing(responses: let responses):
+                        repository.createUnsyncedServerAlarm(
+                            responses: responses
+                        )
+                    case .bothMissing(
+                        localMissingAlarmIds: let localMissingAlarmIds,
+                        serverMissingResponses: let serverMissingResponses
+                    ):
+                        repository.removeUnsyncedServerAlarm(
+                            alarmIds: localMissingAlarmIds
+                        )
+                        repository.createUnsyncedServerAlarm(
+                            responses: serverMissingResponses
+                        )
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+    
+    private func createUnsyncedServerAlarm(responses: [RegularAlarmResponse]) {
+        responses.forEach { response in
+            networkService.request(
+                endPoint: AddRegularAlarmEndPoint(
+                    request: response.toAddRequest
+                )
+            )
+            .decode(
+                type: AddRegularAlarmDTO.self,
+                decoder: JSONDecoder()
+            )
+            .subscribe() // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
+            .dispose()
+        }
+    }
+    
+    private func removeUnsyncedServerAlarm(alarmIds: [String]) {
+        alarmIds.forEach { alarmId in
+            networkService.request(
+                endPoint: RemoveRegularAlarmEndPoint(
+                    request: .init(alarmId: alarmId)
+                )
+            )
+            .decode(
+                type: RemoveRegularAlarmDTO.self,
+                decoder: JSONDecoder()
+            )
+            .subscribe() // 성공, Error에 따라 추가 작업을 해줘야할지 고민입니다
+            .dispose()
         }
     }
 }

--- a/Projects/NetworkService/Sources/EndPoint/RegularAlarmEndPoint/FetchRegularAlarmEndPoint.swift
+++ b/Projects/NetworkService/Sources/EndPoint/RegularAlarmEndPoint/FetchRegularAlarmEndPoint.swift
@@ -1,0 +1,35 @@
+//
+//  FetchRegularAlarmEndPoint.swift
+//  NetworkService
+//
+//  Created by gnksbm on 4/14/24.
+//  Copyright © 2024 Pepsi-Club. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+public struct FetchRegularAlarmEndPoint: RegularAlarmEndPoint {
+    public var port: String {
+        ""
+    }
+    
+    public var query: [String: String] {
+        ["deviceToken": .fcmToken ?? ""]
+    }
+    
+    public var header: [String: String] {
+        [:]
+    }
+    
+    public var body: [String: Any] {
+        [:]
+    }
+    
+    public var method: HTTPMethod {
+        .get
+    }
+    
+    public init() { }
+}


### PR DESCRIPTION
## 작업내용
### 로컬과 서버에 등록된 정규알람 싱크 작업
- EndPoint, DTO 구현
- Core모듈 Sequence.compareDiff 구현
- DTO 배열과 RegularAlarmResponse 배열을 비교해 싱크 상태를 나타내는 RegularAlarmSyncValidation 구현
- RegularAlarmRepository 로직 수정
- 검수가 일찍 끝난다면 1.2.0 버전에 반영하면 될 것 같습니다
## 리뷰요청
- @MUKER-WON 
  - RegularAlarmSyncValidation
    - DTO단에 enum을 활용해 구현해보았는데 외부 함수에서 처리하는 것 보다 더 복잡해 보이시나요?
  - compareDiff
    - 복잡도를 고려해 로직을 구현해보았는데 놓친점이 있을까요?
    - 재사용성이 있다고 생각해 문서화를 처음해봤는데 부족한점이나 가독성에 대한 의견 부탁드려요
  - RegularAlarmRepository
    - 로컬 save, delete 성공 시점마다 fetchRegularAlarm을 호출하면 싱크확인을 위해 네트워킹을 너무 자주한다고 생각해서
  초기화 시점에만 호출하고 save, delete에서 함수호출이 아닌 직접 Observable 이벤트처리하는 방식으로 수정해주었는데 
  기존처럼 함수를 호출해 데이터 변경 시점마다 싱크작업을 해주는게 좋을지 고민입니다
    - 195, 211번줄에 추가 핸들링 작업을 해줘야 하는지 고민입니다
## 관련 이슈
close #228