### PR TITLE
[Feat] 즐겨찾기 정보 Fetch 요청 쓰로틀 작업

### DIFF
--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -28,6 +28,52 @@ public struct BusStopArrivalInfoResponse: Codable, Hashable {
 }
 
 public extension BusStopArrivalInfoResponse {
+    func replaceTime(timerSecond: Int) -> Self {
+        BusStopArrivalInfoResponse(
+            busStopId: busStopId,
+            busStopName: busStopName,
+            direction: direction,
+            buses: buses.map { busInfo in
+                let newFirstArrivalState: ArrivalState
+                let newSecondArrivalState: ArrivalState
+                switch busInfo.firstArrivalState {
+                case .soon, .pending, .finished:
+                    newFirstArrivalState = busInfo.firstArrivalState
+                case .arrivalTime(let time):
+                    newFirstArrivalState = time - timerSecond > 60 ?
+                        .arrivalTime(time: time - timerSecond):
+                        .soon
+                }
+                switch busInfo.secondArrivalState {
+                case .soon, .pending, .finished:
+                    newSecondArrivalState
+                    = busInfo.secondArrivalState
+                case .arrivalTime(let time):
+                    newSecondArrivalState = time - timerSecond > 60 ?
+                        .arrivalTime(time: time - timerSecond):
+                        .soon
+                }
+                let firstReaining = busInfo.firstArrivalRemaining
+                let secondReaining = busInfo.secondArrivalRemaining
+                return BusArrivalInfoResponse(
+                    busId: busInfo.busId,
+                    busName: busInfo.busName,
+                    busType: busInfo.busType.rawValue,
+                    nextStation: busInfo.nextStation,
+                    firstArrivalState: newFirstArrivalState,
+                    firstArrivalRemaining: firstReaining,
+                    secondArrivalState: newSecondArrivalState,
+                    secondArrivalRemaining: secondReaining,
+                    adirection: busInfo.adirection,
+                    isFavorites: busInfo.isFavorites,
+                    isAlarmOn: busInfo.isAlarmOn
+                )
+            }
+        )
+    }
+}
+
+public extension BusStopArrivalInfoResponse {
     func updateFavoritesStatus(
         favoritesList: [FavoritesBusResponse]
     ) -> Self {

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,8 +11,5 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
-    var fetchedArrivalInfo
-    : BehaviorSubject<[BusStopArrivalInfoResponse]> { get }
-    
-    func fetchFavoritesArrivals()
+    func fetchFavoritesArrivals() -> Observable<[BusStopArrivalInfoResponse]>
 }

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -201,13 +201,8 @@ public final class FavoritesViewController: UIViewController {
         .withUnretained(self)
         .observe(on: MainScheduler.asyncInstance)
         .subscribe(
-            onNext: { viewController, arg1 in
-                let (timerTime, responses) = arg1
-                let datas: [Data] = responses.compactMap { response in
-                    guard let data = response.encode()
-                    else { return nil }
-                    return data
-                }
+            onNext: { viewController, tuple in
+                let (timerTime, responses) = tuple
                 let newResponses = responses.map {
                     return BusStopArrivalInfoResponse(
                         busStopId: $0.busStopId,
@@ -264,10 +259,16 @@ public final class FavoritesViewController: UIViewController {
         )
         .disposed(by: disposeBag)
         
+        refreshBtn.rx.tap
+            .observe(on: MainScheduler.asyncInstance)
+            .subscribe(
+                onNext: { _ in
+                    refreshControl.beginRefreshing()
+                }
+            )
+            .disposed(by: disposeBag)
+        
         output.favoritesState
-            .distinctUntilChanged { oldValue, newValue in
-                oldValue == .fakeFetching || newValue == .realFetching
-            }
             .withUnretained(self)
             .subscribe(
                 onNext: { _, state in


### PR DESCRIPTION
## 작업내용
### UseCase 형태 수정
- fetch 함수의 Return 형태를 Void -> Observable<[도착정보]>로 수정
  - UseCase의 public 변수를 제거하며 private bind 함수도 제거
### VM
- fetch 요청 이벤트 처리 구분
    - fakeFetching은 요청 후 3초 뒤에 fake 상태라면 기존의 데이터를 onNext 시키며 fetchComplete 상태로 전환
    - realFetching은 20초 쓰로틀을 추가하고 실제 데이터 통신의 결과 값 처리 후 fetchComplete 상태로 전환
### VC
- 하단의 refresh 애니메이션 제거
    - 상단의 애니메이션과 중복되기에 삭제
- VM.FavoritesState에서 emptyFavorites case를 제거하고 결과 값에 따른 분기처리로 view 업데이트
## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #251