### PR TITLE
[Fix] 검색화면 주변정류장 업데이트 주기 수정

### DIFF
--- a/Projects/Domain/Sources/UseCase/DefaultSearchUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultSearchUseCase.swift
@@ -104,7 +104,8 @@ public final class DefaultSearchUseCase: SearchUseCase {
     
     public func updateNearByStop(
     ) -> Observable<(BusStopInfoResponse, String)> {
-        locationService.locationStatus
+        locationService.requestLocationOnce()
+        return locationService.locationStatus
             .withUnretained(self)
             .map { useCase, status in
                 var response: BusStopInfoResponse

--- a/Projects/Feature/SearchFeature/Sources/ViewModel/SearchViewModel.swift
+++ b/Projects/Feature/SearchFeature/Sources/ViewModel/SearchViewModel.swift
@@ -28,18 +28,21 @@ public final class SearchViewModel: ViewModel {
             recentSearchedResponse: useCase.recentSearchResult,
             nearByStopInfo: .init()
         )
-        
-        input.viewWillAppearEvent
-            .take(1)
-            .withUnretained(self)
-            .subscribe(
-                onNext: { vm, _ in
-                    vm.useCase.updateNearByStop()
-                        .bind(to: output.nearByStopInfo)
-                        .disposed(by: vm.disposeBag)
-                }
-            )
-            .disposed(by: disposeBag)
+        Observable.merge(
+            NotificationCenter.default.rx.notification(
+                UIApplication.willEnterForegroundNotification
+            ).map { _ in },
+            input.viewWillAppearEvent
+        )
+        .withUnretained(self)
+        .subscribe(
+            onNext: { vm, _ in
+                vm.useCase.updateNearByStop()
+                    .bind(to: output.nearByStopInfo)
+                    .disposed(by: vm.disposeBag)
+            }
+        )
+        .disposed(by: disposeBag)
         
         input.removeBtnTapEvent
             .withUnretained(self)


### PR DESCRIPTION
## 작업내용
### 검색화면의 주변정류장 뷰 업데이트 주기 수정
- 기존 
  - viewWillAppear 시점에 1번 업데이트
- 수정
  - viewWillAppear 시점마다 업데이트
  - 앱이 Foreground 상태로 되는 시점마다 업데이트
## 리뷰요청
- @MUKER-WON 

## 관련 이슈
close #262