### PR TITLE
Feat/#255 즐겨찾기 Fetch 페이지네이션 처리

### DIFF
--- a/Projects/App/Widget/ArrivalInfo/ArrivalInfoUseCase.swift
+++ b/Projects/App/Widget/ArrivalInfo/ArrivalInfoUseCase.swift
@@ -19,8 +19,8 @@ final class ArrivalInfoUseCase {
             forKey: "arrivalResponse"
         ) as? [Data]
         else { return }
-        responses = datas.compactMap {
-            return try? $0.decode(type: BusStopArrivalInfoResponse.self)
-        }
+//        responses = datas.compactMap {
+//            return try? $0.decode(type: BusStopArrivalInfoResponse.self)
+//        }
     }
 }

--- a/Projects/App/Widget/ArrivalInfo/View/ArrivalInfoSmallView.swift
+++ b/Projects/App/Widget/ArrivalInfo/View/ArrivalInfoSmallView.swift
@@ -76,7 +76,7 @@ struct ArrivalInfoSmallView: View {
                             .foregroundColor(.green)
                         Spacer()
                         VStack(spacing: 6) {
-                            HStack(spacing:3) {
+                            HStack(spacing: 3) {
                                 Spacer()
                                 Text(bus.firstArrivalState.toString)
                                     .font(.nanumHeavy(13))
@@ -86,7 +86,7 @@ struct ArrivalInfoSmallView: View {
                                 Text(bus.firstArrivalRemaining)
                                     .font(.nanumExtraBold(12))
                             }
-                            HStack(spacing:3) {
+                            HStack(spacing: 3) {
                                 Spacer()
                                 Text(bus.secondArrivalState.toString)
                                     .font(.nanumHeavy(13))

--- a/Projects/App/Widget/Extension/ArrivalState+.swift
+++ b/Projects/App/Widget/Extension/ArrivalState+.swift
@@ -18,7 +18,7 @@ extension ArrivalState {
                 .red
         case .finished:
                 .red
-        case .arrivalTime(time: _):
+        case .arrivalTime:
                 .white
         }
     }

--- a/Projects/Core/Sources/BCTimer.swift
+++ b/Projects/Core/Sources/BCTimer.swift
@@ -8,31 +8,27 @@
 
 import Foundation
 
+import RxSwift
 import RxRelay
 
 public final class BCTimer {
-    private var timer: Timer?
     public var distanceFromStart = BehaviorRelay<Int>(value: 0)
     
+    private var disposeBag = DisposeBag()
     public init() { }
     
-    public func start(interval: TimeInterval = 1) {
-        let startDate = Date()
-        timer = .scheduledTimer(
-            withTimeInterval: interval,
-            repeats: true
-        ) { [weak self] timer in
-            self?.distanceFromStart.accept(
-                Int(
-                    startDate.distance(to: timer.fireDate)
-                )
+    public func start(interval: RxTimeInterval = .seconds(1)) {
+        Observable
+            .interval(
+                interval,
+                scheduler: ConcurrentDispatchQueueScheduler(qos: .utility)
             )
-        }
+            .bind(to: distanceFromStart)
+            .disposed(by: disposeBag)
     }
     
     public func stop() {
+        disposeBag = .init()
         distanceFromStart.accept(0)
-        timer?.invalidate()
-        timer = nil
     }
 }

--- a/Projects/Core/Sources/BCTimer.swift
+++ b/Projects/Core/Sources/BCTimer.swift
@@ -29,6 +29,5 @@ public final class BCTimer {
     
     public func stop() {
         disposeBag = .init()
-        distanceFromStart.accept(0)
     }
 }

--- a/Projects/CoreDataService/Sources/CoreDataDirectory.swift
+++ b/Projects/CoreDataService/Sources/CoreDataDirectory.swift
@@ -10,4 +10,13 @@ import Foundation
 
 enum CoreDataDirectory: Codable {
     case applicationSupport, appGroup
+    
+    var description: String {
+        switch self {
+        case .applicationSupport:
+            return "마이그레이션 필요한 저장소"
+        case .appGroup:
+            return "마이그레이션 완료된 저장소"
+        }
+    }
 }

--- a/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
+++ b/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
@@ -74,7 +74,7 @@ public final class DefaultCoreDataService: CoreDataService {
             #if DEBUG
             print(
                 "💾 CoreData 저장소: \(String(describing: migrationStatus))",
-                "[applicationSupport(마이그레이션 필요) / appGroup(마이그레이션 완)]"
+                "\(migrationStatus.description)"
             )
             #endif
             loadStore()

--- a/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
+++ b/Projects/CoreDataService/Sources/DefaultCoreDataService.swift
@@ -117,19 +117,22 @@ public final class DefaultCoreDataService: CoreDataService {
     public func fetch<T: CoreDataStorable>(
         type: T.Type
     ) -> Observable<[T]> {
-        Observable.create { observer in
-            do {
-                let result = try self.fetchMO(type: type)
-                    .compactMap { $0 as? CoreDataModelObject }
-                    .compactMap { $0.toDomain as? T }
-                observer.onNext(result)
-                observer.onCompleted()
-                return Disposables.create()
-            } catch {
-                observer.onError(error)
-                return Disposables.create()
+        return storeStatus
+            .filter { status in
+                status == .loaded
             }
-        }
+            .take(1)
+            .withUnretained(self)
+            .flatMap { coreDataService, _ in
+                do {
+                    let result = try coreDataService.fetchMO(type: type)
+                        .compactMap { $0 as? CoreDataModelObject }
+                        .compactMap { $0.toDomain as? T }
+                    return Observable.just(result)
+                } catch {
+                    return Observable.error(error)
+                }
+            }
     }
     
     public func fetch<T: CoreDataStorable>(type: T.Type) throws -> [T] {

--- a/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultFavoritesRepository.swift
@@ -82,14 +82,10 @@ public final class DefaultFavoritesRepository: FavoritesRepository {
     
     private func migrateFavorites() {
         coreDataService.fetch(type: FavoritesBusStopResponse.self)
-            .withUnretained(self)
-            .filter { repository, legacyFavoritesList in
-                let needMigration = !legacyFavoritesList.isEmpty
-                if !needMigration {
-//                    repository.fetchFavorites()
-                }
-                return needMigration
+            .filter { legacyFavoritesList in
+                !legacyFavoritesList.isEmpty
             }
+            .withUnretained(self)
             .flatMap { repository, legacyFavoritesList in
                 repository.fetchLegacyFavoritesToBusStop(
                     legacyFavoritesList: legacyFavoritesList.filterDuplicated()
@@ -103,10 +99,10 @@ public final class DefaultFavoritesRepository: FavoritesRepository {
                         busStopList: tuple.0,
                         legacyFavoritesList: tuple.1
                     )
-//                    repository.fetchFavorites()
+                    _ = repository.fetchFavorites()
                 },
                 onError: { [weak self] _ in
-//                    self?.fetchFavorites()
+                    _ = self?.fetchFavorites()
                 }
             )
             .disposed(by: disposeBag)

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -9,18 +9,20 @@
 import Foundation
 
 public struct BusStopArrivalInfoResponse: Hashable {
-    public let generatedDate: Date = .now
+    public let generatedDate: Date
     public let busStopId: String
     public let busStopName: String
     public let direction: String
     public var buses: [BusArrivalInfoResponse]
     
     public init(
+        generatedDate: Date = .now,
         busStopId: String,
         busStopName: String,
         direction: String,
         buses: [BusArrivalInfoResponse]
     ) {
+        self.generatedDate = generatedDate
         self.busStopId = busStopId
         self.busStopName = busStopName
         self.direction = direction
@@ -29,9 +31,11 @@ public struct BusStopArrivalInfoResponse: Hashable {
 }
 
 public extension BusStopArrivalInfoResponse {
-    func replaceTime(timerSecond: Int) -> Self {
-        let distance = Int(generatedDate.distance(to: .now)) + timerSecond
+    func replaceTime() -> Self {
+        let distance = Int(generatedDate.distance(to: .now))
+        print(distance)
         return BusStopArrivalInfoResponse(
+            generatedDate: generatedDate,
             busStopId: busStopId,
             busStopName: busStopName,
             direction: direction,
@@ -88,6 +92,7 @@ public extension BusStopArrivalInfoResponse {
             return updatedBus
         }
         return .init(
+            generatedDate: generatedDate,
             busStopId: busStopId,
             busStopName: busStopName,
             direction: direction,
@@ -100,6 +105,7 @@ public extension BusStopArrivalInfoResponse {
             busResponse.isFavorites
         }
         return BusStopArrivalInfoResponse(
+            generatedDate: generatedDate,
             busStopId: busStopId,
             busStopName: busStopName,
             direction: direction,
@@ -137,6 +143,7 @@ public extension Array<BusStopArrivalInfoResponse> {
             }
             
             return BusStopArrivalInfoResponse(
+                generatedDate: busStop.generatedDate,
                 busStopId: busStop.busStopId,
                 busStopName: busStop.busStopName,
                 direction: busStop.direction,

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -109,6 +109,12 @@ public extension BusStopArrivalInfoResponse {
 }
 
 public extension Array<BusStopArrivalInfoResponse> {
+    func filterUnfavorites(favoritesList: [FavoritesBusResponse]) -> Self {
+        updateFavoritesStatus(favoritesList: favoritesList)
+        .map { $0.filterUnfavoritesBuses() }
+        .filter { !$0.buses.isEmpty }
+    }
+    
     func updateFavoritesStatus(
         favoritesList: [FavoritesBusResponse]
     ) -> Self {

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -33,7 +33,6 @@ public struct BusStopArrivalInfoResponse: Hashable {
 public extension BusStopArrivalInfoResponse {
     func replaceTime() -> Self {
         let distance = Int(generatedDate.distance(to: .now))
-        print(distance)
         return BusStopArrivalInfoResponse(
             generatedDate: generatedDate,
             busStopId: busStopId,

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -28,6 +28,52 @@ public struct BusStopArrivalInfoResponse: Codable, Hashable {
 }
 
 public extension BusStopArrivalInfoResponse {
+    func replaceTime(timerSecond: Int) -> Self {
+        BusStopArrivalInfoResponse(
+            busStopId: busStopId,
+            busStopName: busStopName,
+            direction: direction,
+            buses: buses.map { busInfo in
+                let newFirstArrivalState: ArrivalState
+                let newSecondArrivalState: ArrivalState
+                switch busInfo.firstArrivalState {
+                case .soon, .pending, .finished:
+                    newFirstArrivalState = busInfo.firstArrivalState
+                case .arrivalTime(let time):
+                    newFirstArrivalState = time - timerSecond > 60 ?
+                        .arrivalTime(time: time - timerSecond):
+                        .soon
+                }
+                switch busInfo.secondArrivalState {
+                case .soon, .pending, .finished:
+                    newSecondArrivalState
+                    = busInfo.secondArrivalState
+                case .arrivalTime(let time):
+                    newSecondArrivalState = time - timerSecond > 60 ?
+                        .arrivalTime(time: time - timerSecond):
+                        .soon
+                }
+                let firstReaining = busInfo.firstArrivalRemaining
+                let secondReaining = busInfo.secondArrivalRemaining
+                return BusArrivalInfoResponse(
+                    busId: busInfo.busId,
+                    busName: busInfo.busName,
+                    busType: busInfo.busType.rawValue,
+                    nextStation: busInfo.nextStation,
+                    firstArrivalState: newFirstArrivalState,
+                    firstArrivalRemaining: firstReaining,
+                    secondArrivalState: newSecondArrivalState,
+                    secondArrivalRemaining: secondReaining,
+                    adirection: busInfo.adirection,
+                    isFavorites: busInfo.isFavorites,
+                    isAlarmOn: busInfo.isAlarmOn
+                )
+            }
+        )
+    }
+}
+
+public extension BusStopArrivalInfoResponse {
     func updateFavoritesStatus(
         favoritesList: [FavoritesBusResponse]
     ) -> Self {

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-public struct BusStopArrivalInfoResponse: Codable, Hashable {
+public struct BusStopArrivalInfoResponse: Hashable {
+    public let generatedDate: Date = .now
     public let busStopId: String
     public let busStopName: String
     public let direction: String
@@ -29,7 +30,8 @@ public struct BusStopArrivalInfoResponse: Codable, Hashable {
 
 public extension BusStopArrivalInfoResponse {
     func replaceTime(timerSecond: Int) -> Self {
-        BusStopArrivalInfoResponse(
+        let distance = Int(generatedDate.distance(to: .now)) + timerSecond
+        return BusStopArrivalInfoResponse(
             busStopId: busStopId,
             busStopName: busStopName,
             direction: direction,
@@ -40,8 +42,8 @@ public extension BusStopArrivalInfoResponse {
                 case .soon, .pending, .finished:
                     newFirstArrivalState = busInfo.firstArrivalState
                 case .arrivalTime(let time):
-                    newFirstArrivalState = time - timerSecond > 60 ?
-                        .arrivalTime(time: time - timerSecond):
+                    newFirstArrivalState = time - distance > 60 ?
+                        .arrivalTime(time: time - distance):
                         .soon
                 }
                 switch busInfo.secondArrivalState {
@@ -49,8 +51,8 @@ public extension BusStopArrivalInfoResponse {
                     newSecondArrivalState
                     = busInfo.secondArrivalState
                 case .arrivalTime(let time):
-                    newSecondArrivalState = time - timerSecond > 60 ?
-                        .arrivalTime(time: time - timerSecond):
+                    newSecondArrivalState = time - distance > 60 ?
+                        .arrivalTime(time: time - distance):
                         .soon
                 }
                 let firstReaining = busInfo.firstArrivalRemaining

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -125,6 +125,8 @@ public extension Array<BusStopArrivalInfoResponse> {
                 let key = "\(busStop.busStopId)\(bus.busId)\(bus.adirection)"
                 if let isFavorites = favoritesDic[key] {
                     updatedBuses[index].isFavorites = isFavorites
+                } else {
+                    updatedBuses[index].isFavorites = false
                 }
             }
             

--- a/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/BusStopArrivalInfoResponse.swift
@@ -71,9 +71,7 @@ public extension BusStopArrivalInfoResponse {
             }
         )
     }
-}
-
-public extension BusStopArrivalInfoResponse {
+    
     func updateFavoritesStatus(
         favoritesList: [FavoritesBusResponse]
     ) -> Self {

--- a/Projects/Domain/Sources/Entity/Response/FavoritesBusResponse.swift
+++ b/Projects/Domain/Sources/Entity/Response/FavoritesBusResponse.swift
@@ -33,3 +33,11 @@ public struct FavoritesBusResponse: CoreDataStorable, Equatable {
         self.adirection = adirection
     }
 }
+
+public extension Array<FavoritesBusResponse> {
+    var toBusStopIds: [String] {
+        map { $0.busStopId }
+            .removeDuplicated()
+            .sorted { $0 < $1 }
+    }
+}

--- a/Projects/Domain/Sources/RepositoryInterface/FavoritesRepository.swift
+++ b/Projects/Domain/Sources/RepositoryInterface/FavoritesRepository.swift
@@ -13,7 +13,7 @@ import RxSwift
 public protocol FavoritesRepository {
     var favorites: BehaviorSubject<[FavoritesBusResponse]> { get }
     
-    func fetchFavorites()
+    func fetchFavorites() -> Observable<[FavoritesBusResponse]>
     func addFavorites(favorites: FavoritesBusResponse) throws
     func removeFavorites(favorites: FavoritesBusResponse) throws
 }

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -37,8 +37,8 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
             .flatMap { useCase, favoritesList in
                 let cachedStopId = useCase.cachedResponses.map { $0.busStopId }
                 let favoritesIds = favoritesList.toBusStopIds
-                let missedStopIds = Set(cachedStopId)
-                    .subtracting(Set(favoritesIds))
+                let missedStopIds = Set(favoritesIds)
+                    .subtracting(Set(cachedStopId))
                 guard missedStopIds.isEmpty
                 else {
                     return useCase.fetchFirstPage()

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -35,6 +35,7 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
                 Observable.zip(
                     favoritesList
                         .prefix(useCase.fetchItemLimit)
+                        .prefix(5)
                         .map {
                             $0.busStopId
                         }

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -46,9 +46,7 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
                     useCase.cachedResponses
                         .prefix(useCase.fetchItemLimit)
                 )
-                .updateFavoritesStatus(favoritesList: favoritesList)
-                .map { $0.filterUnfavoritesBuses() }
-                .filter { !$0.buses.isEmpty }
+                .filterUnfavorites(favoritesList: favoritesList)
                 return Observable.just(cachedResult)
             }
     }
@@ -107,12 +105,7 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
             .map { useCase, tuple in
                 let (responses, favoritesList) = tuple
                 let result = (useCase.cachedResponses + responses)
-                    .updateFavoritesStatus(
-                        favoritesList: favoritesList
-                    )
-                    .map { response in
-                        response.filterUnfavoritesBuses()
-                    }
+                    .filterUnfavorites(favoritesList: favoritesList)
                 return result
             }
             .share()

--- a/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultFavoritesUseCase.swift
@@ -69,8 +69,12 @@ public final class DefaultFavoritesUseCase: FavoritesUseCase {
             .take(1)
             .withUnretained(self)
             .flatMapLatest { useCase, favoritesList in
-                useCase.isFinalPage
-                = favoritesList.count < useCase.fetchItemLimit
+                if favoritesList.count < useCase.fetchItemLimit {
+                    useCase.isFinalPage = true
+                    return Observable.just(
+                        ([BusStopArrivalInfoResponse](), favoritesList)
+                    )
+                }
                 let suffixCount = useCase.fetchItemLimit > 5 ?
                 min(favoritesList.count % 5, 5) :
                 5

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,6 +11,7 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
+    var isFinalPage: Bool { get }
     func fakeFetch() -> Observable<[BusStopArrivalInfoResponse]>
     func fetchFirstPage() -> Observable<[BusStopArrivalInfoResponse]>
     func fetchNextPage() -> Observable<[BusStopArrivalInfoResponse]>

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,8 +11,7 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
-    func fetchAllFavorites() -> Observable<[BusStopArrivalInfoResponse]>
-    
+    func fakeFetchComplete()
     func fetchFirstPage() -> Observable<[BusStopArrivalInfoResponse]>
     func fetchNextPage() -> Observable<[BusStopArrivalInfoResponse]>
 }

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,8 +11,5 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
-    var fetchedArrivalInfo
-    : BehaviorSubject<[BusStopArrivalInfoResponse]> { get }
-    
-    func fetchFavoritesArrivals()
+    func fetchFavoritesArrivals() -> Observable<[BusStopArrivalInfoResponse]>
 }

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,7 +11,7 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
-    func fakeFetchComplete()
+    func fakeFetch() -> Observable<[BusStopArrivalInfoResponse]>
     func fetchFirstPage() -> Observable<[BusStopArrivalInfoResponse]>
     func fetchNextPage() -> Observable<[BusStopArrivalInfoResponse]>
 }

--- a/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Protocol/FavoritesUseCase.swift
@@ -11,5 +11,8 @@ import Foundation
 import RxSwift
 
 public protocol FavoritesUseCase {
-    func fetchFavoritesArrivals() -> Observable<[BusStopArrivalInfoResponse]>
+    func fetchAllFavorites() -> Observable<[BusStopArrivalInfoResponse]>
+    
+    func fetchFirstPage() -> Observable<[BusStopArrivalInfoResponse]>
+    func fetchNextPage() -> Observable<[BusStopArrivalInfoResponse]>
 }

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -198,13 +198,18 @@ public final class FavoritesViewController: UIViewController {
         
         output.fetchStatus
             .observe(on: MainScheduler.asyncInstance)
+            .withUnretained(self)
             .subscribe(
-                onNext: { state in
+                onNext: { vc, state in
                     switch state {
                     case .firstFetching, .nextFetching, .fakeFetching:
                         refreshControl.beginRefreshing()
                     case .fetchComplete, .finalPage:
                         refreshControl.endRefreshing()
+                        vc.refreshBtn.configuration?.attributedTitle = .init(
+                            "\(Date.now.toString(dateFormat: "HH:mm")) 업데이트",
+                            attributes: vc.refreshAttribute
+                        )
                     }
                 }
             )

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -201,13 +201,8 @@ public final class FavoritesViewController: UIViewController {
         .withUnretained(self)
         .observe(on: MainScheduler.asyncInstance)
         .subscribe(
-            onNext: { viewController, arg1 in
-                let (timerTime, responses) = arg1
-                let datas: [Data] = responses.compactMap { response in
-                    guard let data = response.encode()
-                    else { return nil }
-                    return data
-                }
+            onNext: { viewController, tuple in
+                let (timerTime, responses) = tuple
                 let newResponses = responses.map {
                     return BusStopArrivalInfoResponse(
                         busStopId: $0.busStopId,
@@ -264,10 +259,16 @@ public final class FavoritesViewController: UIViewController {
         )
         .disposed(by: disposeBag)
         
+        refreshBtn.rx.tap
+            .observe(on: MainScheduler.asyncInstance)
+            .subscribe(
+                onNext: { _ in
+                    refreshControl.beginRefreshing()
+                }
+            )
+            .disposed(by: disposeBag)
+        
         output.favoritesState
-            .distinctUntilChanged { oldValue, newValue in
-                oldValue == .fakeFetching || newValue == .realFetching
-            }
             .withUnretained(self)
             .subscribe(
                 onNext: { _, state in

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -12,6 +12,7 @@ public final class FavoritesViewController: UIViewController {
     
     private let headerTapEvent = PublishSubject<String>()
     private let alarmBtnTapEvent = PublishSubject<IndexPath>()
+    private let scrollReachedBtmEvent = PublishSubject<Void>()
     private let isTableViewEditMode = BehaviorSubject(value: false)
     private let disposeBag = DisposeBag()
     
@@ -165,7 +166,8 @@ public final class FavoritesViewController: UIViewController {
                     refreshBtn.rx.tap.asObservable()
                 ),
                 alarmBtnTapEvent: alarmBtnTapEvent.asObservable(),
-                busStopTapEvent: headerTapEvent
+                busStopTapEvent: headerTapEvent,
+                scrollReachedBtmEvent: scrollReachedBtmEvent
             )
         )
         
@@ -199,9 +201,9 @@ public final class FavoritesViewController: UIViewController {
             .subscribe(
                 onNext: { state in
                     switch state {
-                    case .realFetching, .fakeFetching:
+                    case .firstFetching, .nextFetching, .fakeFetching:
                         refreshControl.beginRefreshing()
-                    case .fetchComplete:
+                    case .fetchComplete, .finalPage:
                         refreshControl.endRefreshing()
                     }
                 }
@@ -284,6 +286,13 @@ public final class FavoritesViewController: UIViewController {
 }
 
 extension FavoritesViewController: UITableViewDelegate {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y >
+            scrollView.contentSize.height - scrollView.bounds.height {
+            scrollReachedBtmEvent.onNext(())
+        }
+    }
+    
     public func tableView(
         _ tableView: UITableView,
         viewForFooterInSection section: Int

--- a/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewController/FavoritesViewController.swift
@@ -12,7 +12,7 @@ public final class FavoritesViewController: UIViewController {
     
     private let headerTapEvent = PublishSubject<String>()
     private let alarmBtnTapEvent = PublishSubject<IndexPath>()
-    private let scrollReachedBtmEvent = PublishSubject<Int>()
+    private let scrollReachedBottomEvent = PublishSubject<Int>()
     private let isTableViewEditMode = BehaviorSubject(value: false)
     private let disposeBag = DisposeBag()
     
@@ -167,7 +167,7 @@ public final class FavoritesViewController: UIViewController {
                 ),
                 alarmBtnTapEvent: alarmBtnTapEvent.asObservable(),
                 busStopTapEvent: headerTapEvent,
-                scrollReachedBtmEvent: scrollReachedBtmEvent
+                scrollReachedBottomEvent: scrollReachedBottomEvent
                     .throttle(
                         .seconds(1),
                         latest: false,
@@ -301,7 +301,7 @@ extension FavoritesViewController: UITableViewDelegate {
             .map {
                 Int(scrollView.contentSize.height)
             }
-            .bind(to: scrollReachedBtmEvent)
+            .bind(to: scrollReachedBottomEvent)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -30,7 +30,7 @@ public final class FavoritesViewModel: ViewModel {
         let output = Output(
             busStopArrivalInfoResponse: .init(),
             fetchStatus: .init(),
-            distanceFromTimerStart: .init(value: 0)
+            distanceFromTimerStart: .init()
         )
         
         let fetchRequest = Observable.merge(
@@ -105,9 +105,9 @@ public final class FavoritesViewModel: ViewModel {
             .withUnretained(self)
             .subscribe(
                 onNext: { vm, responses in
-                    vm.timer.start()
                     output.fetchStatus.onNext(.fetchComplete)
                     output.busStopArrivalInfoResponse.onNext(responses)
+                    vm.timer.start()
                 }
             )
             .disposed(by: disposeBag)
@@ -184,7 +184,7 @@ extension FavoritesViewModel {
         var busStopArrivalInfoResponse
         : PublishSubject<[BusStopArrivalInfoResponse]>
         var fetchStatus: PublishSubject<FetchStatus>
-        var distanceFromTimerStart: BehaviorRelay<Int>
+        var distanceFromTimerStart: PublishSubject<Int>
     }
     
     enum FetchStatus {

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -170,7 +170,7 @@ public final class FavoritesViewModel: ViewModel {
             .map { tuple in
                 let (timerValue, responses) = tuple
                 return responses.map {
-                    return $0.replaceTime(timerSecond: timerValue)
+                    return $0.replaceTime()
                 }
             }
             .distinctUntilChanged()

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -120,7 +120,7 @@ public final class FavoritesViewModel: ViewModel {
             )
             .disposed(by: disposeBag)
         
-        input.scrollReachedBtmEvent // nextFetch 상태 업데이트 및 이벤트 처리
+        input.scrollReachedBottomEvent // nextFetch 상태 업데이트 및 이벤트 처리
             .withLatestFrom(vmFetchStatus)
             .filter { status in
                 status == .fetchComplete
@@ -188,7 +188,7 @@ extension FavoritesViewModel {
         let refreshBtnTapEvent: Observable<Void>
         let alarmBtnTapEvent: Observable<IndexPath>
         let busStopTapEvent: Observable<String>
-        let scrollReachedBtmEvent: Observable<Void>
+        let scrollReachedBottomEvent: Observable<Void>
     }
     
     public struct Output {

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -67,7 +67,7 @@ public final class FavoritesViewModel: ViewModel {
             }
             .withUnretained(self)
             .flatMap { vm, _ in
-                vm.useCase.fetchFavoritesArrivals()
+                vm.useCase.fetchAllFavorites()
             }
             .withUnretained(self)
             .subscribe(

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -36,13 +36,7 @@ public final class FavoritesViewModel: ViewModel {
         
         vmFetchStatus // VMStatus, VCStatus 바인딩
             .map { status in
-                print(status)
-                switch status {
-                case .firstFetching, .nextFetching, .fakeFetching:
-                    return .fetching
-                case .fetchComplete, .finalPage:
-                    return .fetchComplete
-                }
+                status.toVC
             }
             .bind(to: output.fetchStatus)
             .disposed(by: disposeBag)
@@ -122,15 +116,6 @@ public final class FavoritesViewModel: ViewModel {
                     vm.vmFetchStatus.onNext(.fetchComplete)
                     vm.fetchedResponse.onNext(responses)
                     vm.timer.start()
-                }
-            )
-            .disposed(by: disposeBag)
-        
-        input.scrollReachedBtmEvent
-            .withLatestFrom(vmFetchStatus)
-            .subscribe(
-                onNext: { status in
-                    print(status)
                 }
             )
             .disposed(by: disposeBag)
@@ -216,6 +201,15 @@ extension FavoritesViewModel {
         case firstFetching, nextFetching
         case fakeFetching
         case fetchComplete, finalPage
+        
+        var toVC: VCFetchStatus {
+            switch self {
+            case .firstFetching, .nextFetching, .fakeFetching:
+                return .fetching
+            case .fetchComplete, .finalPage:
+                return .fetchComplete
+            }
+        }
     }
     
     enum VCFetchStatus {

--- a/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/ViewModel/FavoritesViewModel.swift
@@ -134,7 +134,6 @@ public final class FavoritesViewModel: ViewModel {
                         output.fetchStatus.onNext(.finalPage)
                     } else {
                         let newResponses = (newPage + oldPage)
-                            .removeDuplicated()
                         output.busStopArrivalInfoResponse.onNext(newResponses)
                         output.fetchStatus.onNext(.fetchComplete)
                     }

--- a/Projects/FeatureDependency/Sources/Mock/MockFavoritesRepository.swift
+++ b/Projects/FeatureDependency/Sources/Mock/MockFavoritesRepository.swift
@@ -14,6 +14,7 @@ import RxSwift
 
 #if DEBUG
 public final class MockFavoritesRepository: FavoritesRepository {
+    
     public var favorites = BehaviorSubject<[FavoritesBusResponse]>(
         value: []
     )
@@ -23,6 +24,10 @@ public final class MockFavoritesRepository: FavoritesRepository {
     }
     public func fetchFavorites() {
         
+    }
+    public func fetchFavorites(
+    ) -> RxSwift.Observable<[Domain.FavoritesBusResponse]> {
+        .empty()
     }
     public func addFavorites(favorites: FavoritesBusResponse) throws {
         


### PR DESCRIPTION
## 작업내용
### UseCase 
- 첫번째 page fetch 함수 구현
- 다음 page fetch 함수 구현
- fakeFetch 시점에 사용하는 함수 구현
### VM
- FetchStatus
  - realFetching 제거
  - 첫번째 페이지 fetching, 다음 페이지 fetching, 마지막 페이지 상태 추가
  - 상태에 따라 필요한 로직 구현
### VC
- 스크롤 감지 이벤트 추가
  - VM 바인딩
### BCTimer
- Swift의 Timer 제거 -> Observable<Int> 의 interval 메서드 사용 형태로 수정
### CoreDataService
- 디버깅 로그 보기 쉽게 수정
## 리뷰요청
- @MUKER-WON 
  - VM의 Fetch 상태가 많아져 코드가 복잡해 보이는데 개선방안이 있다면 알려주세요!
## 관련 이슈
close #255 