### PR TITLE
Fix/#287 NearMapView에 InformainView 세브론UI 설정

### DIFF
--- a/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
@@ -44,6 +44,26 @@ public final class NearMapViewController: UIViewController {
         return view
     }()
     
+    private lazy var busStopInformationViewChevron: UIImageView = {
+        let configuration = UIImage.SymbolConfiguration(
+            pointSize: 16,
+            weight: .regular
+        )
+        let image = UIImage(
+            systemName: "chevron.right",
+            withConfiguration: configuration
+        )
+        var view = UIImageView(image: image)
+        view.tintColor = DesignSystemAsset.remainingColor.color
+        switch self.viewModel.viewMode {
+        case .normal:
+            break
+        case .focused(let busStopId):
+            view.isHidden = true
+        }
+        return view
+    }()
+    
     init(viewModel: NearMapViewModel) {
         self.viewModel = viewModel
         super.init(
@@ -87,7 +107,11 @@ public final class NearMapViewController: UIViewController {
     
     private func configureUI() {
         view.backgroundColor = DesignSystemAsset.cellColor.color
-        [busStopInformationView, naverMap].forEach {
+        [
+            busStopInformationView,
+            naverMap,
+            busStopInformationViewChevron
+        ].forEach {
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -126,6 +150,15 @@ public final class NearMapViewController: UIViewController {
                 equalTo: busStopInformationView.topAnchor,
                 constant: -10
             ),
+            
+            busStopInformationViewChevron.centerYAnchor.constraint(
+                equalTo: busStopInformationView.centerYAnchor,
+                constant: 10
+            ),
+            busStopInformationViewChevron.trailingAnchor.constraint(
+                equalTo: busStopInformationView.trailingAnchor,
+                constant: -10
+            ),
         ])
     }
     
@@ -148,7 +181,13 @@ public final class NearMapViewController: UIViewController {
             .withUnretained(self)
             .subscribe(
                 onNext: { vc, tuple in
-                    let (response, distance) = tuple
+                    var (response, distance) = tuple
+                    switch vc.viewModel.viewMode {
+                    case .normal:
+                        break
+                    case .focused(let busStopId):
+                        distance = "알수없음"
+                    }
                     vc.busStopInformationView.updateUI(
                         response: response,
                         distance: distance

--- a/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
@@ -12,7 +12,7 @@ import NMapsMap
 public final class NearMapViewModel: LeafMarkerUpdater, ViewModel {
     @Injected(NearMapUseCase.self) var useCase: NearMapUseCase
     private let coordinator: NearMapCoordinator
-    private let viewMode: NearMapMode
+    private(set) var viewMode: NearMapMode
     
     private let disposeBag = DisposeBag()
 	
@@ -154,7 +154,7 @@ extension NearMapViewModel {
 }
 
 extension NearMapViewModel {
-    private enum NearMapMode {
+    enum NearMapMode {
         case normal, focused(busStopId: String)
     }
 }

--- a/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewModel/NearMapViewModel.swift
@@ -13,7 +13,6 @@ public final class NearMapViewModel: LeafMarkerUpdater, ViewModel {
     @Injected(NearMapUseCase.self) var useCase: NearMapUseCase
     private let coordinator: NearMapCoordinator
     private(set) var viewMode: NearMapMode
-    
     private let disposeBag = DisposeBag()
 	
     public init(


### PR DESCRIPTION
## 작업내용
NearMapView에 InformainView 세브론UI 추가
<img width="392" alt="스크린샷 2024-05-09 오후 5 25 45" src="https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/91649269/4f1a2583-7183-4216-9746-c474d0793f74">


viewMode(뷰컨 flow)의 접근제어를 private -> private(set) 으로 낮추고 상태를 ViewController에서 사용했습니다.

## 리뷰요청
- @yuhaeun-la 

## 관련 이슈
close #287 