### PR TITLE
Fix/#292 distance에 '알수없음'이 들어오는 로직 수정

### DIFF
--- a/Projects/Domain/Sources/UseCase/DefaultNearMapUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/DefaultNearMapUseCase.swift
@@ -103,9 +103,12 @@ public final class DefaultNearMapUseCase: NearMapUseCase {
                     }
                 }.first
             if let selectedBusStop {
-                let distance = locationService.getDistance(
+                var distance = locationService.getDistance(
                     response: selectedBusStop
                 )
+                if distance.isEmpty {
+                    distance = "알수없음"
+                }
                 return (selectedBusStop, distance)
             } else {
                 return (errorResponse, errorDistance)

--- a/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
+++ b/Projects/Feature/NearMapFeature/Sources/ViewController/NearMapViewController.swift
@@ -182,12 +182,6 @@ public final class NearMapViewController: UIViewController {
             .subscribe(
                 onNext: { vc, tuple in
                     var (response, distance) = tuple
-                    switch vc.viewModel.viewMode {
-                    case .normal:
-                        break
-                    case .focused(let busStopId):
-                        distance = "알수없음"
-                    }
                     vc.busStopInformationView.updateUI(
                         response: response,
                         distance: distance


### PR DESCRIPTION
## 작업내용
distance가 빈문자열로 들어올 때 알수없음이 나오도록 수정
busStop에서 NearMap으로 넘어올 때 모든 정류장을 다 돌고 있는 로직이 있는거 같은데
해당 부분 리팩토링 필요해 보임

## 리뷰요청
- @yuhaeun-la 

## 관련 이슈
close #292 