### PR TITLE
UI/#291 Cell에 text 흘러넘치는 UI오류

### DIFF
--- a/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
+++ b/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
@@ -35,7 +35,7 @@ public final class BusStopInformationView: UIView {
     private let busStopDescription: UILabel = {
         let label = UILabel()
         label.font = .nanumRegular(size: 13)
-        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.8
         label.textColor = .adaptiveBlack.withAlphaComponent(0.8)
         return label

--- a/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
+++ b/Projects/Feature/NearMapFeature/Sources/View/BusStopInformationView.swift
@@ -127,7 +127,8 @@ public final class BusStopInformationView: UIView {
                 equalTo: busStopNameLabel.leadingAnchor
             ),
             busStopDescription.trailingAnchor.constraint(
-                equalTo: busStopNameLabel.trailingAnchor
+                equalTo: trailingAnchor,
+                constant: -15
             ),
             busStopDescription.topAnchor.constraint(
                 equalTo: busStopNameLabel.bottomAnchor,

--- a/Projects/Feature/SearchFeature/Sources/View/BusStopInfoView.swift
+++ b/Projects/Feature/SearchFeature/Sources/View/BusStopInfoView.swift
@@ -118,6 +118,10 @@ public final class BusStopInfoView: UIView {
             descriptionLabel.leadingAnchor.constraint(
                 equalTo: busStopNameLabel.leadingAnchor
             ),
+            descriptionLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -15
+            ),
             descriptionLabel.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
                 constant: -15


### PR DESCRIPTION
## 작업내용
| cell text 벗어남 | cell 사이즈 맞추기 |
| -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-05-09 at 20 49 05](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/a360b842-0a34-46f8-b965-24b0189f024c) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-09 at 23 55 29](https://github.com/Pepsi-Club/WhereMyBus-iOS/assets/133845468/df5ea33c-96d2-4135-b0ef-3ff02b07b129) |

Cell의 사이즈 지정 및 NearMap에서 busStopInfomationView에 나오는 busDescription label에 scale factor 적용

## 리뷰요청
- @yuhaeun-la 

## 관련 이슈
close #291 