### PR TITLE
Fix/#305 RuntimeError BugFix 

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -21,13 +21,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         setupAppearance()
         registerDependencies()
         configureNotification(application: application)
-        configureFirebase(application: application)
         #if DEBUG
         configureDebuggingFB(application: application)
         var newArguments = ProcessInfo.processInfo.arguments
         newArguments.append("-FIRDebugEnabled")
         ProcessInfo.processInfo.setValue(newArguments, forKey: "arguments")
+        #else
+        configureFirebase(application: application)
         #endif
+        
         return true
     }
 


### PR DESCRIPTION
## 작업내용
Appdelegate 코드 오류로 Firebase.configuration()이 두번 불리져서 런타임에러가 나는걸 확인했습니다.
코드 순서를 바꾸고 확실하게 release일때만 configureFirebase()함수가 불릴 수 있도록 수정했습니다

## 리뷰요청
- @MUKER-WON  

## 관련 이슈
close #305 