### PR TITLE
Fix/#320 네트워크 통신 로직수정 및 의존성 수정

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -29,12 +29,6 @@ let project = Project.makeProject(
 //            ]
 //        )
     ],
-    packages: [
-        .remote(
-            url: "https://github.com/firebase/firebase-ios-sdk",
-            requirement: .exact("10.23.1")
-        ),
-    ],
     dependencies: [
         .mainFeature,
         .data,

--- a/Projects/Data/Project.swift
+++ b/Projects/Data/Project.swift
@@ -5,6 +5,16 @@ import ProjectDescriptionHelpers
 let project = Project.makeProject(
     name: "Data",
     moduleType: .dynamicFramework,
+    packages: [
+        .remote(
+            url: "https://github.com/google/GoogleUtilities.git",
+            requirement: .exact("7.13.1")
+        ),
+        .remote(
+            url: "https://github.com/firebase/firebase-ios-sdk",
+            requirement: .exact("10.23.1")
+        ),
+    ],
     dependencies: [
         .networkService,
         .coreDataService,

--- a/Projects/NetworkService/Sources/EndPoint/EndPoint.swift
+++ b/Projects/NetworkService/Sources/EndPoint/EndPoint.swift
@@ -24,7 +24,7 @@ public enum Scheme: String {
 }
 
 extension EndPoint {
-    public var toURLRequest: URLRequest? {
+    public func toURLRequest() throws -> URLRequest {
         var urlComponent = URLComponents()
         urlComponent.scheme = scheme.rawValue
         urlComponent.host = host
@@ -38,7 +38,7 @@ extension EndPoint {
         guard let urlStr = urlComponent.url?.absoluteString
             .replacingOccurrences(of: "%25", with: "%"),
               let url = URL(string: urlStr)
-        else { return nil }
+        else { throw NetworkError.invalidURL }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.toString
         urlRequest.allHTTPHeaderFields = header
@@ -47,11 +47,10 @@ extension EndPoint {
                 let httpBody = try JSONSerialization.data(withJSONObject: body)
                 urlRequest.httpBody = httpBody
             } catch {
-                #if DEBUG
-                print(error.localizedDescription)
-                #endif
+                throw NetworkError.jsonSerializationError(error)
             }
         }
         return urlRequest
+        
     }
 }

--- a/Projects/NetworkService/Sources/NetworkError.swift
+++ b/Projects/NetworkService/Sources/NetworkError.swift
@@ -9,22 +9,28 @@
 import Foundation
 
 enum NetworkError: LocalizedError {
+    case invalidURL
+    case jsonSerializationError(Error)
     case transportError(Error)
+    case invalidResponse
     case invalidStatusCode(Int)
     case invalidData
-    case invalidURL
     case parseError
     
     var errorDescription: String? {
         switch self {
+        case .invalidURL:
+            return "유효하지 않은 URL입니다."
+        case .jsonSerializationError(let error):
+            return "JSON 직렬화 에러: \(error.localizedDescription)"
         case .transportError(let error):
-            return "에러: \(error.localizedDescription)"
+            return "네트워크 요청 에러: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "유효하지 않은 응답입니다."
         case .invalidStatusCode(let code):
             return "서버 응답 코드 에러: \(code)"
         case .invalidData:
             return "유효하지 않은 데이터입니다."
-        case .invalidURL:
-            return "유효하지 않은 URL입니다."
         case .parseError:
             return "데이터 파싱에 실패하였습니다."
         }

--- a/Projects/NetworkService/Sources/NetworkService/DefaultNetworkService.swift
+++ b/Projects/NetworkService/Sources/NetworkService/DefaultNetworkService.swift
@@ -14,45 +14,47 @@ public final class DefaultNetworkService: NetworkService {
     public init() { }
     
     public func request(endPoint: EndPoint) -> Observable<Data> {
-        .create { observer in
-            guard let urlRequest = endPoint.toURLRequest
-            else {
+        Observable.create { observer in
+            do {
+                let urlRequest = try endPoint.toURLRequest()
+                let task = URLSession.shared.dataTask(
+                    with: urlRequest
+                ) { data, response, error in
+                    if let error {
+                        observer.onError(NetworkError.transportError(error))
+                        return
+                    }
+                    guard let httpURLResponse = response as? HTTPURLResponse
+                    else {
+                        observer.onError(
+                            NetworkError.invalidResponse
+                        )
+                        return
+                    }
+                    guard 200..<300 ~= httpURLResponse.statusCode
+                    else {
+                        observer.onError(
+                            NetworkError.invalidStatusCode(
+                                httpURLResponse.statusCode
+                            )
+                        )
+                        return
+                    }
+                    guard let data
+                    else {
+                        observer.onError(NetworkError.invalidData)
+                        return
+                    }
+                    observer.onNext(data)
+                    observer.onCompleted()
+                }
+                task.resume()
+                return Disposables.create {
+                    task.cancel()
+                }
+            } catch {
                 observer.onError(NetworkError.invalidURL)
                 return Disposables.create()
-            }
-            
-            let task = URLSession.shared.dataTask(
-                with: urlRequest
-            ) { data, response, error in
-                if let error {
-                    observer.onError(NetworkError.transportError(error))
-                    return
-                }
-                
-                guard let httpURLResponse = response as? HTTPURLResponse
-                else { return }
-                guard 200..<300 ~= httpURLResponse.statusCode
-                else {
-                    observer.onError(
-                        NetworkError.invalidStatusCode(
-                            httpURLResponse.statusCode
-                        )
-                    )
-                    return
-                }
-                
-                guard let data
-                else {
-                    observer.onError(NetworkError.invalidData)
-                    return
-                }
-                observer.onNext(data)
-                observer.onCompleted()
-            }
-            task.resume()
-            
-            return Disposables.create {
-                task.cancel()
             }
         }
     }

--- a/Projects/NetworkService/Sources/NetworkService/DefaultNetworkService.swift
+++ b/Projects/NetworkService/Sources/NetworkService/DefaultNetworkService.swift
@@ -21,7 +21,7 @@ public final class DefaultNetworkService: NetworkService {
                 return Disposables.create()
             }
             
-            URLSession.shared.dataTask(
+            let task = URLSession.shared.dataTask(
                 with: urlRequest
             ) { data, response, error in
                 if let error {
@@ -38,31 +38,6 @@ public final class DefaultNetworkService: NetworkService {
                             httpURLResponse.statusCode
                         )
                     )
-                    #if DEBUG
-                    if let url = urlRequest.url,
-                       let httpMethod = urlRequest.httpMethod,
-                       let data = urlRequest.httpBody,
-                       let httpBody = String(
-                        data: data,
-                        encoding: .utf8
-                       ) {
-                        print(
-                            url,
-                            httpMethod,
-                            httpBody,
-                            separator: "\n"
-                        )
-                    }
-                    if let data,
-                    let json = String(
-                        data: data,
-                        encoding: .utf8
-                    ) {
-                        print(
-                            json
-                        )
-                    }
-                    #endif
                     return
                 }
                 
@@ -73,9 +48,12 @@ public final class DefaultNetworkService: NetworkService {
                 }
                 observer.onNext(data)
                 observer.onCompleted()
-            }.resume()
+            }
+            task.resume()
             
-            return Disposables.create()
+            return Disposables.create {
+                task.cancel()
+            }
         }
     }
 }


### PR DESCRIPTION
## 작업내용
### NetworkService
- URLSessionTask 리턴 Observable dispose 시점에 취소
- 에러 핸들링 추가
### 의존성 수정
- Firebase
  - App 모듈의 Firebase 패키지 제거
  - Data 모듈 Firebase 패키지 추가  
- GoogleUtilities
  - Module name "GoogleUtilities-Privacy" is not a valid identifier 에러로 빌드가 되지 않는 문제 발생
  - 동일한 증상의 Issue를 리서치 하였고 7.13.1 버전에서 문제가 잘 동작함을 확인
    - https://github.com/google/GoogleUtilities/issues/146
  - 버스어디는 Firebase 10.23.1 버전을 사용하고 있고 Firebase 10.23.1는 GoogleUtilities를 7.12.1 ..< 8.0.0 버전으로 사용중
  - GoogleUtilities를 7.31.1 버전 고정으로 의존성 추가
## 리뷰요청
- @MUKER-WON 
  - Firebase SPM 패키지 추가가 App 모듈에서 되고있어 Data 모듈로 수정하였는데 App 모듈에서 추가하신 이유가 있으신가요?  

## 관련 이슈
close #320